### PR TITLE
Integral filtering on active space and integral screening; misc. bugfixes

### DIFF
--- a/arches/io.py
+++ b/arches/io.py
@@ -5,7 +5,6 @@ from itertools import takewhile
 from typing import Dict, List, NewType, Tuple
 
 from arches.integral_indexing_utils import compound_idx2, compound_idx4
-
 from arches.legacy.fundamental_types import (
     Determinant,
 )
@@ -35,7 +34,9 @@ def manipulate_line(raw_line, used_zip):
 # Integrals of the Hamiltonian over molecular orbitals
 # ~
 def load_integrals(
-    fcidump_path, return_N_elec=False
+    fcidump_path,
+    return_N_elec=False,
+    return_size_only=False,
 ) -> Tuple[int, float, One_electron_integral, Two_electron_integral]:
     """Read all the Hamiltonian integrals from the data file.
     Returns: (E0, d_one_e_integral, d_two_e_integral).
@@ -76,6 +77,9 @@ def load_integrals(
     n_orb = int(line.split()[2])
     n_elec = int(line.split()[5])
 
+    if return_size_only:
+        return n_orb, n_elec
+
     # Using takewhile we 'take lines from the file' while '/' has not been found
     # Needed so we can start reading data on the integrals.
     lines = list(takewhile(lambda line: "/" not in manipulate_line(line, used_zip), f))  # noqa
@@ -110,6 +114,10 @@ def load_integrals(
         return n_orb, n_elec, E0, d_one_e_integral, d_two_e_integral
     else:
         return n_orb, E0, d_one_e_integral, d_two_e_integral
+
+
+def get_mo_size():
+    pass
 
 
 def load_wf(path_wf, det_representation="tuple") -> Tuple[List[float], List[Determinant]]:

--- a/arches/io.py
+++ b/arches/io.py
@@ -116,10 +116,6 @@ def load_integrals(
         return n_orb, E0, d_one_e_integral, d_two_e_integral
 
 
-def get_mo_size():
-    pass
-
-
 def load_wf(path_wf, det_representation="tuple") -> Tuple[List[float], List[Determinant]]:
     """Read the input file :
     Representation of the Slater determinants (basis) and

--- a/arches/src/determinant.cpp
+++ b/arches/src/determinant.cpp
@@ -513,19 +513,19 @@ void Dets_DetArray_setitem(DetArray *arr, det_t *other, idx_t i) { arr->arr[i] =
 //// Det generation routines
 
 DetArray *Dets_get_connected_singles(det_t *source, idx_t N_dets) {
-    return new DetArray(get_all_singles(*source));
+    return new DetArray(get_all_singles(*source), source);
 }
 
 DetArray *Dets_get_connected_same_spin_doubles(det_t *source, idx_t N_dets) {
-    return new DetArray(get_ss_doubles(*source));
+    return new DetArray(get_ss_doubles(*source), source);
 }
 
 DetArray *Dets_get_connected_opp_spin_doubles(det_t *source, idx_t N_dets) {
-    return new DetArray(get_os_doubles(*source, false));
+    return new DetArray(get_os_doubles(*source, false), source);
 }
 
 DetArray *Dets_get_connected_dets(det_t *source, idx_t N_dets) {
-    return new DetArray(get_all_connected_dets(source, N_dets));
+    return new DetArray(get_all_connected_dets(source, N_dets), source);
 }
 
 DetArray *Dets_get_constrained_singles(det_t *source, idx_t N_dets, idx_t *h_a, idx_t N_h_a,
@@ -539,7 +539,7 @@ DetArray *Dets_get_constrained_singles(det_t *source, idx_t N_dets, idx_t *h_a, 
     const exc_constraint_t a(ah, ap);
     const exc_constraint_t b(bh, bp);
 
-    return new DetArray(get_constrained_singles(*source, a, b));
+    return new DetArray(get_constrained_singles(*source, a, b), source);
 }
 
 DetArray *Dets_get_constrained_same_spin_doubles(det_t *source, idx_t N_dets, idx_t *h_a,
@@ -553,7 +553,7 @@ DetArray *Dets_get_constrained_same_spin_doubles(det_t *source, idx_t N_dets, id
     const exc_constraint_t a(ah, ap);
     const exc_constraint_t b(bh, bp);
 
-    return new DetArray(get_constrained_ss_doubles(*source, a, b));
+    return new DetArray(get_constrained_ss_doubles(*source, a, b), source);
 }
 
 DetArray *Dets_get_constrained_opp_spin_doubles(det_t *source, idx_t N_dets, idx_t *h_a,
@@ -567,7 +567,7 @@ DetArray *Dets_get_constrained_opp_spin_doubles(det_t *source, idx_t N_dets, idx
     const exc_constraint_t a(ah, ap);
     const exc_constraint_t b(bh, bp);
 
-    return new DetArray(get_constrained_os_doubles(*source, a, b, false));
+    return new DetArray(get_constrained_os_doubles(*source, a, b, false), source);
 }
 
 DetArray *Dets_get_constrained_dets(det_t *source, idx_t N_dets, idx_t *h_a, idx_t N_h_a,
@@ -581,7 +581,7 @@ DetArray *Dets_get_constrained_dets(det_t *source, idx_t N_dets, idx_t *h_a, idx
     const exc_constraint_t a(ah, ap);
     const exc_constraint_t b(bh, bp);
 
-    return new DetArray(get_constrained_connected_dets(source, N_dets, a, b));
+    return new DetArray(get_constrained_connected_dets(source, N_dets, a, b), source);
 }
 
 SymCSRMatrix<float> *Dets_get_H_structure_naive_f32(DetArray *psi_det) {

--- a/arches/src/include/determinant.h
+++ b/arches/src/include/determinant.h
@@ -331,10 +331,10 @@ class DetArray {
         arr = &storage[0];
     }
 
-    // move constructor
-    DetArray(const std::vector<det_t> &&other) {
+    // safer move connstructor
+    DetArray(const std::vector<det_t> &&other, det_t *source) {
         size = other.size();
-        N_mos = other[0].N_mos;
+        N_mos = source->N_mos; // in case other has no dets
         storage = std::move(other);
         arr = &storage[0];
     }

--- a/arches/src/include/determinant.h
+++ b/arches/src/include/determinant.h
@@ -31,14 +31,14 @@ class spin_det_t {
     idx_t N_blocks;
     mo_block_t *block_arr;
     mo_block_t read_mask;
-    mo_block_t block_size;
+    mo_block_t block_size = sizeof(mo_block_t) * 8;
 
     // needed for det_t to compile
-    spin_det_t(){};
+    spin_det_t() { read_mask = ((mo_block_t)1) << (block_size - 1); };
 
     // empty initialization
     spin_det_t(idx_t min_mos) {
-        block_size = sizeof(mo_block_t) * 8;
+        // block_size = sizeof(mo_block_t) * 8;
         read_mask = ((mo_block_t)1) << (block_size - 1);
 
         N_mos = min_mos;

--- a/arches/src/include/matrix.h
+++ b/arches/src/include/matrix.h
@@ -71,13 +71,13 @@ template <class T> class SymCSRMatrix {
         n = N;
 
         // allocate row pointer array
-        std::unique_ptr<idx_t[]> A_p_tmp(new idx_t[m + 1]);
+        std::unique_ptr<idx_t[]> A_p_tmp(new idx_t[M + 1]);
         A_p_ptr = std::move(A_p_tmp);
         A_p = A_p_ptr.get();
-        std::copy(arr_p, arr_p + m, A_p);
+        std::copy(arr_p, arr_p + M, A_p);
 
         // allocate col arr
-        idx_t n_entries = A_p[m];
+        idx_t n_entries = arr_p[M];
         std::unique_ptr<idx_t[]> A_c_tmp(new idx_t[n_entries]);
         A_c_ptr = std::move(A_c_tmp);
         A_c = A_c_ptr.get();

--- a/arches/src/include/matrix.h
+++ b/arches/src/include/matrix.h
@@ -74,10 +74,10 @@ template <class T> class SymCSRMatrix {
         std::unique_ptr<idx_t[]> A_p_tmp(new idx_t[M + 1]);
         A_p_ptr = std::move(A_p_tmp);
         A_p = A_p_ptr.get();
-        std::copy(arr_p, arr_p + M, A_p);
+        std::copy(arr_p, arr_p + M + 1, A_p);
 
         // allocate col arr
-        idx_t n_entries = arr_p[M];
+        idx_t n_entries = A_p[M];
         std::unique_ptr<idx_t[]> A_c_tmp(new idx_t[n_entries]);
         A_c_ptr = std::move(A_c_tmp);
         A_c = A_c_ptr.get();

--- a/tests/example.py
+++ b/tests/example.py
@@ -5,6 +5,7 @@ import numpy as np
 from arches.algorithms import evaluate_H_entries, s_CI
 from arches.determinant import det_t, spin_det_t
 from arches.integrals import load_integrals_into_chunks
+from arches.io import load_integrals
 from arches.linked_object import LinkedArray_idx_t, get_LArray
 from arches.log_timer import logtimer
 from arches.matrix import DMatrix, SymCSRMatrix
@@ -55,12 +56,17 @@ config_map = (
 
 @logtimer(config_map, report_on=("call",))
 def run_example(fp, config, dtype):
-    N_orbs, N_elec, V_nn, chunks = load_integrals_into_chunks(str(fp), FakeComm(0, 1), dtype=dtype)
-
+    N_orbs, N_elec = load_integrals(str(fp), return_size_only=True)
     ground_det = get_ground_state(N_orbs, N_elec)
     ground_psi = DMatrix(1, 1, 1.0, dtype=dtype)
-
     config["constraint"] = get_constraint(ground_det, *config["constraint"])
+
+    N_orbs, N_elec, V_nn, chunks = load_integrals_into_chunks(
+        str(fp),
+        FakeComm(0, 1),
+        dtype=dtype,
+        constraint=config["constraint"],
+    )
 
     E0 = get_E0(ground_det, chunks, V_nn, dtype)
 

--- a/tests/example.py
+++ b/tests/example.py
@@ -66,6 +66,8 @@ def run_example(fp, config, dtype):
         FakeComm(0, 1),
         dtype=dtype,
         constraint=config["constraint"],
+        chunk_size=512,
+        screening_threshold=config["screening_threshold"],
     )
 
     E0 = get_E0(ground_det, chunks, V_nn, dtype)
@@ -78,10 +80,11 @@ def nh3(dtype):
     fp = pathlib.Path("../data/nh3.5det.fcidump")
     config = {
         "N_states": 1,
-        "N_max_dets": 1000,
-        "pt2_conv": 1e-4,
-        "pt2_threshold": 1e-6,
-        "constraint": (3, 3),
+        "N_max_dets": 2000,
+        "pt2_conv": 1e-6,
+        "pt2_threshold": 1e-8,
+        "constraint": (4, 4),
+        "screening_threshold": 1e-8,
     }
     run_example(fp, config, dtype)
     print("###### NH3 example finished ######\n")
@@ -92,10 +95,11 @@ def f2(dtype):
     fp = pathlib.Path("../data/f2_631g.18det.fcidump")
     config = {
         "N_states": 1,
-        "N_max_dets": 1000,
-        "pt2_conv": 1e-4,
-        "pt2_threshold": 1e-6,
-        "constraint": (3, 3),
+        "N_max_dets": 2000,
+        "pt2_conv": 1e-6,
+        "pt2_threshold": 1e-8,
+        "constraint": (4, 4),
+        "screening_threshold": 1e-8,
     }
     run_example(fp, config, dtype)
     print("###### F2 example finished ######\n")
@@ -106,10 +110,11 @@ def c2(dtype):
     fp = pathlib.Path("../data/c2_eq_hf_dz.fcidump")
     config = {
         "N_states": 1,
-        "N_max_dets": 1000,
-        "pt2_conv": 1e-4,
-        "pt2_threshold": 1e-7,
-        "constraint": (3, 3),
+        "N_max_dets": 2000,
+        "pt2_conv": 1e-6,
+        "pt2_threshold": 1e-8,
+        "constraint": (4, 4),
+        "screening_threshold": 1e-8,
     }
     run_example(fp, config, dtype)
     print("###### C2 example finished ######\n")

--- a/tests/test_integrals.py
+++ b/tests/test_integrals.py
@@ -113,14 +113,15 @@ class Test_ChunkFactory(unittest.TestCase):
                 len(ref_ind), len(idx), msg=f"Some indices double counted in category {cat}"
             )
 
-        check_category("A", list(JChunkFactory.A_idx_iter(self.N_mos)))
-        check_category("B", list(JChunkFactory.B_idx_iter(self.N_mos)))
-        check_category("C", list(JChunkFactory.C_idx_iter(self.N_mos)))
-        check_category("D", list(JChunkFactory.D_idx_iter(self.N_mos)))
-        check_category("E", list(JChunkFactory.E_idx_iter(self.N_mos)))
-        check_category("F", list(JChunkFactory.F_idx_iter(self.N_mos)))
-        check_category("G", list(JChunkFactory.G_idx_iter(self.N_mos)))
-        check_category("OE", list(JChunkFactory.OE_idx_iter(self.N_mos)))
+        orbs = range(self.N_mos)
+        check_category("A", list(JChunkFactory.A_idx_iter(orbs)))
+        check_category("B", list(JChunkFactory.B_idx_iter(orbs)))
+        check_category("C", list(JChunkFactory.C_idx_iter(orbs)))
+        check_category("D", list(JChunkFactory.D_idx_iter(orbs)))
+        check_category("E", list(JChunkFactory.E_idx_iter(orbs)))
+        check_category("F", list(JChunkFactory.F_idx_iter(orbs)))
+        check_category("G", list(JChunkFactory.G_idx_iter(orbs)))
+        check_category("OE", list(JChunkFactory.OE_idx_iter(orbs)))
 
     def test_idx(self):
         def check_category(cat):


### PR DESCRIPTION
Implementation of basic integral screening features

- Chunk factory can now take orbital constraints and will only iterate over all orbitals in the active space instead of all molecular orbitals
- With batched chunks, can now screen integrals via an absolute threshold
- Fixed seg fault issue when attempting to access the MO basis size after empty determinant arrays were returned from constrained generation routines
- Fixed seg fault issue arising from incorrect copy size in sparse matrix constructor